### PR TITLE
Allow setting device id by `-gpu`.

### DIFF
--- a/dqn_main.cpp
+++ b/dqn_main.cpp
@@ -6,7 +6,7 @@
 #include "prettyprint.hpp"
 #include "dqn.hpp"
 
-DEFINE_bool(gpu, false, "Use GPU to brew Caffe");
+DEFINE_int32(gpu, -1, "Use GPU to brew Caffe on given device ID.");
 DEFINE_bool(gui, false, "Open a GUI window");
 DEFINE_string(rom, "breakout.bin", "Atari 2600 ROM to play");
 DEFINE_string(solver, "dqn_solver.prototxt", "Solver parameter file (*.prototxt)");
@@ -98,7 +98,9 @@ int main(int argc, char** argv) {
   google::InstallFailureSignalHandler();
   google::LogToStderr();
 
-  if (FLAGS_gpu) {
+  if (FLAGS_gpu >= 0) {
+    LOG(INFO) << "Use GPU with device ID " << FLAGS_gpu;
+    caffe::Caffe::SetDevice(FLAGS_gpu);
     caffe::Caffe::set_mode(caffe::Caffe::GPU);
   } else {
     caffe::Caffe::set_mode(caffe::Caffe::CPU);


### PR DESCRIPTION
Hi, we are using your repo. At first, it's confusing when we find setting `device_id` and `solver_mode` in `dqn_solver.prototxt` does not work. There are inconsistency with the API of the official `caffe` tool. 

I think the inconsistency with the official `caffe` tool does not matter, however, I think: at least it's necessary for me to be able to set `device_id` by command line arguments like this:
```
./dqn -gpu 2
```
this is a little patch.

btw, Thank you for your work.